### PR TITLE
OO 3.* and uv

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,15 +9,6 @@ import sys
 script_directory = os.path.dirname(os.path.realpath(__file__))
 os.chdir(script_directory)
 
-# Install uv
-subprocess.run([sys.executable, "-m", "pip", "install", "uv"], check=True)
-
-# Create virtual environment
-subprocess.run(["uv", "venv"], check=True)
-
-# Install packages in the virtual environment
-subprocess.run(["uv", "pip", "install", "."], check=True)
-
-command_args = [r".venv\Scripts\python", "-m", "robot_framework"] + sys.argv[1:]
-
+subprocess.run("pip install --upgrade uv", check=True)
+command_args = ["uv", "run", "python", "-m", "robot_framework"] + sys.argv[1:]
 subprocess.run(command_args, check=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robot_framework"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
   { name="ITK Development", email="itk-rpa@mkb.aarhus.dk" },
 ]
@@ -16,7 +16,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-    "OpenOrchestrator == 1.*",
+    "OpenOrchestrator == 3.*",
     "Pillow == 10.*",
     "pandas==2.2.3",
     "requests",


### PR DESCRIPTION
Bump OpenOrchestrator dependency to 3.* and switch main.py to the uv-based bootstrap.